### PR TITLE
Make libgmm_umd module built as shared library.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -110,4 +110,4 @@ LOCAL_EXPORT_C_INCLUDE_DIRS = \
     $(LOCAL_PATH)/Source/inc \
     $(LOCAL_PATH)/Source/inc/common \
 
-include $(BUILD_STATIC_LIBRARY)
+include $(BUILD_SHARED_LIBRARY)

--- a/Source/GmmLib/inc/External/Common/GmmLibDllName.h
+++ b/Source/GmmLib/inc/External/Common/GmmLibDllName.h
@@ -31,7 +31,7 @@ OTHER DEALINGS IN THE SOFTWARE.
     #if defined(_WIN64)
         #define GMM_UMD_DLL           "igdgmm64.dll"
     #elif defined(ANDROID)
-        #define GMM_UMD_DLL           "libigdgmm.so"
+        #define GMM_UMD_DLL           "libgmm_umd.so"
     #else
         #define GMM_UMD_DLL           "libigdgmm.so.11"
     #endif
@@ -45,7 +45,7 @@ OTHER DEALINGS IN THE SOFTWARE.
     #if defined(_WIN32)
         #define GMM_UMD_DLL     "igdgmm32.dll"
     #elif defined(ANDROID)
-        #define GMM_UMD_DLL     "libigdgmm.so"
+        #define GMM_UMD_DLL     "libgmm_umd.so"
     #else
         #define GMM_UMD_DLL     "libigdgmm.so.11"
     #endif


### PR DESCRIPTION
This module will be shared with OpenCL module, so make it as
shared so file and changed module name to libgmm_umd.

Tracked-On: OAM-91697
Change-Id: Ie2f7e910f82c050d78ca538be71884fe9a9aacd6
Signed-off-by: Wan Shuang <shuang.wan@intel.com>