### PR TITLE
Revert "GMMLIB code changes to support rpl platform"

### DIFF
--- a/Source/GmmLib/Platform/GmmGen12Platform.cpp
+++ b/Source/GmmLib/Platform/GmmGen12Platform.cpp
@@ -314,7 +314,6 @@ FCRECTALIGN(TILE__64_2D_128bpe, 128,  32,  32,   32, 32);
     else if(GFX_GET_CURRENT_PRODUCT(Data.Platform) == IGFX_ALDERLAKE_S ||
        (GFX_GET_CURRENT_PRODUCT(Data.Platform) == IGFX_ALDERLAKE_P) || 
        (GFX_GET_CURRENT_PRODUCT(Data.Platform) == IGFX_ALDERLAKE_N) ||
-       (GFX_GET_CURRENT_PRODUCT(Data.Platform) == IGFX_RAPTORLAKE_S) ||
        (GFX_GET_CURRENT_PRODUCT(Data.Platform) >= IGFX_XE_HP_SDV))
     {
         Data.NoOfBitsSupported                = 46;

--- a/Source/inc/common/igfxfmid.h
+++ b/Source/inc/common/igfxfmid.h
@@ -70,7 +70,6 @@ typedef enum {
     IGFX_ROCKETLAKE,
     IGFX_ALDERLAKE_S,
     IGFX_ALDERLAKE_P,
-    IGFX_RAPTORLAKE_S,
     IGFX_ALDERLAKE_N,
     IGFX_DG1  = 1210,
     IGFX_XE_HP_SDV = 1250,
@@ -106,7 +105,6 @@ typedef enum {
     PCH_JSP_N,          // JSL N PCH Device IDs for JSL+ Rev02
     PCH_ADL_S,          // ADL_S PCH
     PCH_ADL_P,          // ADL_P PCH
-    PCH_RPL_S,          // RPL_S PCH
     PCH_TGL_H,          // TGL H PCH
     PCH_ADL_N,          // ADL_N PCHDL
     PCH_MTL,            // MTL PCH
@@ -1337,20 +1335,6 @@ typedef enum __NATIVEGTTYPE
 #define DEV_ID_46C1                             0x46C1
 #define DEV_ID_46C2                             0x46C2
 #define DEV_ID_46C3                             0x46C3
-
-//RPL-S PCH Device IDs
-#define DEV_ID_A780                             0xA780
-#define DEV_ID_A781                             0xA781
-#define DEV_ID_A782                             0xA782
-#define DEV_ID_A783                             0xA783
-
-// RPL-P
-#define DEV_ID_A7A0                             0xA7A0
-#define DEV_ID_A7A1                             0xA7A1
-#define DEV_ID_A7A8                             0xA7A8
-#define DEV_ID_A7A9                             0xA7A9
-#define DEV_ID_A720                             0xA720
-#define DEV_ID_A721                             0xA721
 
 //ICL PCH LP Device IDs
 #define ICP_LP_RESERVED_FUSE_ID                 0x3480


### PR DESCRIPTION
This reverts commit ee91a88d3863d1a900434e7ceacdd9c0ccb6777d. This patch will cause the buffer can not be handled by i915 on ADL with GVT-d

as below

06-29 02:30:22.260 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480
06-29 02:30:22.165 516 585 E hwc-drm-atomic-state-manager: Failed to commit pset ret=-16
06-29 02:30:22.165 516 585 E hwc-drm-atomic-state-manager: Composite failed for pipeline HDMI-A-2
06-29 02:30:22.165 516 585 E hwc-drm-atomic-state-manager: Failed to commit pset ret=-16
06-29 02:30:22.165 516 585 E hwc-drm-atomic-state-manager: Failed to clean-up active composition for pipeline HDMI-A-2
06-29 02:30:22.165 516 585 E hwc-display: Failed to apply the frame composition ret=-16
06-29 02:30:22.165 535 535 E HWComposer: presentAndGetReleaseFences: present failed for display 4640546737361125120: BadParameter (4)
06-29 02:30:22.261 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480
06-29 02:30:22.261 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480
06-29 02:30:22.262 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480
06-29 02:30:22.263 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480
06-29 02:30:22.264 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480
06-29 02:30:22.265 0 0 E i915 0000: 00:02.0: [drm] ERROR Fault errors on pipe A: 0x00000480

Revert this patch

Tracked-On: OAM-110957