### PR TITLE
Build gmmlib as a shared library

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -67,8 +67,14 @@ cc_library_static {
     ],
 
     cflags: [
+        "-Wno-logical-op-parentheses",
         "-Wno-error",
         "-Wno-unused-parameter",
+        "-msse2",
+        "-msse3",
+        "-mssse3",
+        "-msse4.1",
+        "-msse4.2",
         "-DGMM_LIB_DLL",
         "-DGMM_LIB_DLL_EXPORTS",
         "-DGMM_UNIFIED_LIB",
@@ -87,6 +93,14 @@ cc_library_static {
     ],
 
     cppflags: [
+        "-Wno-implicit-fallthrough",
+        "-Wno-missing-braces",
+        "-Wno-parentheses-equality",
+        "-Wno-logical-not-parentheses",
+        "-Wno-missing-field-initializers",
+        "-Wno-unknown-pragmas",
+        "-Wno-parentheses",
+        "-Wno-pragma-pack",
         "-fexceptions",
         "-std=c++11",
     ],
@@ -101,6 +115,7 @@ cc_library_static {
         "Source/GmmLib/Platform",
         "Source/util",
         "Source/inc/umKmInc",
+        "Source/install",
     ],
 
     export_include_dirs: [

--- a/Android.bp
+++ b/Android.bp
@@ -115,7 +115,6 @@ cc_library_static {
         "Source/GmmLib/Platform",
         "Source/util",
         "Source/inc/umKmInc",
-        "Source/install",
     ],
 
     export_include_dirs: [

--- a/Android.bp
+++ b/Android.bp
@@ -18,7 +18,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-cc_library_static {
+cc_library_shared {
 
     name: "libgmm_umd",
     proprietary: true,
@@ -90,6 +90,36 @@ cc_library_static {
         "-D__STDC_LIMIT_MACROS",
         "-D__UMD",
         "-Digfx_gmmumd_dll_EXPORTS",
+	"-Digfx_gmmumd_dll_EXPORTS",
+	"-O3",
+	"-DNDEBUG",
+	"-fPIC",
+	"-march=core-avx2",
+	"-mpopcnt",
+	"-mfpmath=sse",
+	"-finline-functions",
+	"-fno-short-enums",
+	"-Wa,--noexecstack",
+	"-fno-strict-aliasing",
+	"-DUSE_MMX",
+	"-DUSE_SSE",
+	"-DUSE_SSE2",
+	"-DUSE_SSE3",
+	"-DUSE_SSSE3",
+	"-fstack-protector",
+	"-fdata-sections",
+	"-ffunction-sections",
+	"-fmessage-length=0",
+	"-fvisibility=hidden",
+	"-fPIC",
+	"-g",
+	"-funswitch-loops",
+	"-Wl,--no-undefined",
+	"-Wl,--no-as-needed",
+	"-Wl,--gc-sections",
+	"-O2",
+	"-fno-omit-frame-pointer",
+	"-pthread",
     ],
 
     cppflags: [
@@ -103,6 +133,11 @@ cc_library_static {
         "-Wno-pragma-pack",
         "-fexceptions",
         "-std=c++11",
+	"-fvisibility-inlines-hidden",
+	"-fno-use-cxa-atexit",
+	"-fno-rtti",
+	"-fcheck-new",
+	"-pthread",
     ],
 
     local_include_dirs: [

--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,112 @@
+// Copyright(c) 2018 Intel Corporation
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files(the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and / or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+cc_library_static {
+
+    name: "libgmm_umd",
+    proprietary: true,
+    srcs: [
+        "Source/GmmLib/CachePolicy/GmmCachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmCachePolicyCommon.cpp",
+        "Source/GmmLib/CachePolicy/GmmGen10CachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmGen11CachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmGen12CachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmGen12dGPUCachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmGen8CachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmGen9CachePolicy.cpp",
+        "Source/GmmLib/CachePolicy/GmmXe_LPGCachePolicy.cpp",
+        "Source/GmmLib/GlobalInfo/GmmClientContext.cpp",
+        "Source/GmmLib/GlobalInfo/GmmInfo.cpp",
+        "Source/GmmLib/GlobalInfo/GmmLibDllMain.cpp",
+        "Source/GmmLib/Platform/GmmGen10Platform.cpp",
+        "Source/GmmLib/Platform/GmmGen11Platform.cpp",
+        "Source/GmmLib/Platform/GmmGen12Platform.cpp",
+        "Source/GmmLib/Platform/GmmGen8Platform.cpp",
+        "Source/GmmLib/Platform/GmmGen9Platform.cpp",
+        "Source/GmmLib/Platform/GmmPlatform.cpp",
+        "Source/GmmLib/Resource/GmmResourceInfo.cpp",
+        "Source/GmmLib/Resource/GmmResourceInfoCommon.cpp",
+        "Source/GmmLib/Resource/GmmResourceInfoCommonEx.cpp",
+        "Source/GmmLib/Resource/GmmRestrictions.cpp",
+        "Source/GmmLib/Resource/Linux/GmmResourceInfoLinCWrapper.cpp",
+        "Source/GmmLib/Texture/GmmGen10Texture.cpp",
+        "Source/GmmLib/Texture/GmmGen11Texture.cpp",
+        "Source/GmmLib/Texture/GmmGen12Texture.cpp",
+        "Source/GmmLib/Texture/GmmGen7Texture.cpp",
+        "Source/GmmLib/Texture/GmmGen8Texture.cpp",
+        "Source/GmmLib/Texture/GmmGen9Texture.cpp",
+        "Source/GmmLib/Texture/GmmTexture.cpp",
+        "Source/GmmLib/Texture/GmmTextureAlloc.cpp",
+        "Source/GmmLib/Texture/GmmTextureOffset.cpp",
+        "Source/GmmLib/Texture/GmmTextureSpecialCases.cpp",
+        "Source/GmmLib/Texture/GmmXe_LPGTexture.cpp",
+        "Source/GmmLib/TranslationTable/GmmAuxTable.cpp",
+        "Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp",
+        "Source/GmmLib/TranslationTable/GmmUmdTranslationTable.cpp",
+        "Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c",
+        "Source/GmmLib/Utility/GmmLog/GmmLog.cpp",
+        "Source/GmmLib/Utility/GmmUtility.cpp",
+        "Source/Common/AssertTracer/AssertTracer.cpp",
+    ],
+
+    cflags: [
+        "-Wno-error",
+        "-Wno-unused-parameter",
+        "-DGMM_LIB_DLL",
+        "-DGMM_LIB_DLL_EXPORTS",
+        "-DGMM_UNIFIED_LIB",
+        "-DGMM_UNIFY_DAF_API",
+        "-DISTDLIB_UMD",
+        "-DSMALL_POOL_ALLOC",
+        "-DUNUSED_ISTDLIB_MT",
+        "-D_ATL_NO_WIN_SUPPORT",
+        "-D_X64",
+        "-D__GFX_MACRO_C__",
+        "-D__GMM",
+        "-D__STDC_CONSTANT_MACROS",
+        "-D__STDC_LIMIT_MACROS",
+        "-D__UMD",
+        "-Digfx_gmmumd_dll_EXPORTS",
+    ],
+
+    cppflags: [
+        "-fexceptions",
+        "-std=c++11",
+    ],
+
+    local_include_dirs: [
+        "Source/GmmLib",
+        "Source/GmmLib/Utility/GmmLog",
+        "Source/GmmLib/Utility",
+        "Source/GmmLib/GlobalInfo",
+        "Source/GmmLib/Texture",
+        "Source/GmmLib/Resource",
+        "Source/GmmLib/Platform",
+        "Source/util",
+        "Source/inc/umKmInc",
+    ],
+
+    export_include_dirs: [
+        "Source/GmmLib/inc",
+        "Source/inc",
+        "Source/inc/common",
+    ],
+
+}

--- a/Source/GmmLib/GlobalInfo/GmmLibDllMain.cpp
+++ b/Source/GmmLib/GlobalInfo/GmmLibDllMain.cpp
@@ -35,6 +35,25 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "External/Common/GmmLibDll.h"
 
 /////////////////////////////////////////////////////////////////////////////////////
+/// First Call to GMM Lib DLL/so to get the DLL/so exported fucntion pointers
+///
+/////////////////////////////////////////////////////////////////////////////////////
+extern "C" GMM_LIB_API GMM_STATUS GMM_STDCALL OpenGmm(GmmExportEntries *pm_GmmFuncs)
+{
+    GMM_STATUS Status = GMM_SUCCESS;
+    if(pm_GmmFuncs)
+    {
+        //TODO
+    }
+    else
+    {
+        Status = GMM_INVALIDPARAM;
+    }
+
+    return Status;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
 // First Call to GMM Lib DLL/so to initialize singleton global context
 // and create client context
 /////////////////////////////////////////////////////////////////////////////////////

--- a/Source/GmmLib/inc/External/Common/GmmInfo.h
+++ b/Source/GmmLib/inc/External/Common/GmmInfo.h
@@ -627,8 +627,8 @@ typedef struct _GMM_ADAPTER_INFO_
         GMM_ADAPTER_INFO *              GetAdapterNode(ADAPTER_BDF sBdf);   // Replacement for GetAdapterIndex, now get adapter node from the linked list
 
         // Mutexes which protect the below thread unsafe functions
-        GMM_STATUS                      LockMAContextSyncMutex();
-        GMM_STATUS                      UnLockMAContextSyncMutex();
+        GMM_STATUS GMM_STDCALL          LockMAContextSyncMutex();
+        GMM_STATUS GMM_STDCALL          UnLockMAContextSyncMutex();
 
         // thread unsafe functions; these must be protected with LockMAContextSyncMutex
         GMM_ADAPTER_INFO *              GetAdapterNodeUnlocked(ADAPTER_BDF sBdf);

--- a/Source/GmmLib/inc/External/Common/GmmLibDll.h
+++ b/Source/GmmLib/inc/External/Common/GmmLibDll.h
@@ -68,6 +68,7 @@ extern "C" {
 /////////////////////////////////////////////////////////////////////////////////////
 /// Only function exported from GMM lib DLL.
 /////////////////////////////////////////////////////////////////////////////////////
+    GMM_LIB_API GMM_STATUS GMM_STDCALL OpenGmm(GmmExportEntries *pm_GmmFuncs);
     GMM_LIB_API GMM_STATUS GMM_STDCALL InitializeGmm(GMM_INIT_IN_ARGS *pInArgs, GMM_INIT_OUT_ARGS *pOutArgs);
     GMM_LIB_API void GMM_STDCALL GmmAdapterDestroy(GMM_INIT_OUT_ARGS *pInArgs);
 

--- a/Source/GmmLib/inc/External/Common/GmmLibDllName.h
+++ b/Source/GmmLib/inc/External/Common/GmmLibDllName.h
@@ -22,7 +22,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #if defined(_WIN64 ) || defined(__x86_64__) || defined(__LP64__)
+    #define GMM_ENTRY_NAME            "OpenGmm"
+    #define GMM_INIT_NAME             "GmmInit"
     #define GMM_ADAPTER_INIT_NAME     "InitializeGmm"
+    #define GMM_DESTROY_NAME          "GmmDestroy"
     #define GMM_ADAPTER_DESTROY_NAME  "GmmAdapterDestroy"
 
     #if defined(_WIN64)
@@ -33,7 +36,10 @@ OTHER DEALINGS IN THE SOFTWARE.
         #define GMM_UMD_DLL           "libigdgmm.so.12"
     #endif
 #else
+    #define GMM_ENTRY_NAME            "_OpenGmm@4"
+    #define GMM_INIT_NAME             "_GmmInit@48"
     #define GMM_ADAPTER_INIT_NAME     "_InitializeGmm@8"
+    #define GMM_DESTROY_NAME          "_GmmDestroy@4"
     #define GMM_ADAPTER_DESTROY_NAME  "_GmmAdapterDestroy@4"
 
     #if defined(_WIN32)

--- a/Source/inc/common/igfxfmid.h
+++ b/Source/inc/common/igfxfmid.h
@@ -640,6 +640,12 @@ typedef enum __NATIVEGTTYPE
 #define ICHV_PLUS_DESK_DEVICE_F0_ID      0x22B3   // Reserved
 
 //BDW device ids
+#define IBDW_GT0_DESK_DEVICE_F0_ID              0x0BD0
+#define IBDW_GT1_DESK_DEVICE_F0_ID              0x0BD1
+#define IBDW_GT2_DESK_DEVICE_F0_ID              0x0BD2
+#define IBDW_GT3_DESK_DEVICE_F0_ID              0x0BD3
+#define IBDW_GT4_DESK_DEVICE_F0_ID              0x0BD4
+
 #define IBDW_GT1_HALO_MOBL_DEVICE_F0_ID         0x1602
 #define IBDW_GT1_ULT_MOBL_DEVICE_F0_ID          0x1606
 #define IBDW_GT1_RSVD_DEVICE_F0_ID              0x160B


### PR DESCRIPTION
Build gmmlib as a shared library as same as how it is compiled on upstream. If it is still compiled as static library. it could cause a crash in getting VAlign.

Tracked-On: OAM-113684