### PR TITLE
Build gmmlib as a shared library

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18,7 +18,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-cc_library_static {
+cc_library_shared {
 
     name: "libgmm_umd",
     proprietary: true,
@@ -90,6 +90,36 @@ cc_library_static {
         "-D__STDC_LIMIT_MACROS",
         "-D__UMD",
         "-Digfx_gmmumd_dll_EXPORTS",
+	"-Digfx_gmmumd_dll_EXPORTS",
+	"-O3",
+	"-DNDEBUG",
+	"-fPIC",
+	"-march=core-avx2",
+	"-mpopcnt",
+	"-mfpmath=sse",
+	"-finline-functions",
+	"-fno-short-enums",
+	"-Wa,--noexecstack",
+	"-fno-strict-aliasing",
+	"-DUSE_MMX",
+	"-DUSE_SSE",
+	"-DUSE_SSE2",
+	"-DUSE_SSE3",
+	"-DUSE_SSSE3",
+	"-fstack-protector",
+	"-fdata-sections",
+	"-ffunction-sections",
+	"-fmessage-length=0",
+	"-fvisibility=hidden",
+	"-fPIC",
+	"-g",
+	"-funswitch-loops",
+	"-Wl,--no-undefined",
+	"-Wl,--no-as-needed",
+	"-Wl,--gc-sections",
+	"-O2",
+	"-fno-omit-frame-pointer",
+	"-pthread",
     ],
 
     cppflags: [
@@ -103,6 +133,11 @@ cc_library_static {
         "-Wno-pragma-pack",
         "-fexceptions",
         "-std=c++11",
+	"-fvisibility-inlines-hidden",
+	"-fno-use-cxa-atexit",
+	"-fno-rtti",
+	"-fcheck-new",
+	"-pthread",
     ],
 
     local_include_dirs: [


### PR DESCRIPTION
Build gmmlib as a shared library as same as how it is compiled on upstream. If it is still compiled as static library. it could cause a crash in getting VAlign.

Tracked-On: OAM-113684